### PR TITLE
Update Typstry.jl to v0.3.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -35,7 +35,7 @@ Makie = "0.21.2"
 Poppler_jll = "21.9, 22, 23"
 Rsvg = "1"
 julia = "1.9"
-Typstry = "0.2"
+Typstry = "0.3"
 tectonic_jll = "0"
 
 [extras]

--- a/docs/src/formats.md
+++ b/docs/src/formats.md
@@ -63,7 +63,7 @@ fig
 ```@example main
 using MakieTeX, CairoMakie
 
-typst_string = typst"$ integral_0^pi sin(x)^2 diff x $";
+typst_string = typst"$ integral_0^pi sin(x)^2 dif x $";
 typst_document = TypstDocument(typst_string);
 cached_typst = CachedTypst(typst_document);
 

--- a/src/rendering/typst.jl
+++ b/src/rendering/typst.jl
@@ -14,12 +14,13 @@ Compile the given document as a String and return the resulting PDF (also as a S
 """
 function compile_typst(document::AbstractString)
     #=
-    Typst_jll v0.11+ supports compiling from `stdin`.
-    It does not yet support compiling to `stdout`.
+    Typst_jll v0.11+ supports reading from `stdin`.
+    Typst_jll v0.12+ will likely support writing to `stdout`.
 
     See also:
     https://github.com/typst/typst/issues/410
     https://github.com/typst/typst/pull/3339
+    https://github.com/typst/typst/pull/3632
     =#
     return mktempdir() do dir
         cd(dir) do
@@ -39,7 +40,7 @@ function compile_typst(document::AbstractString)
             try
                 # `pipeline` is not yet supported for `TypstCommand`
                 redirect_stdio(stdout=out, stderr=err) do
-                    run(ignorestatus(typst`compile temp.typ`))
+                    run(ignorestatus(addenv(typst`compile temp.typ`, "TYPST_FONT_PATHS" => julia_mono)))
                 end
 
                 close(out.in)

--- a/src/rendering/typst.jl
+++ b/src/rendering/typst.jl
@@ -40,7 +40,7 @@ function compile_typst(document::AbstractString)
             try
                 # `pipeline` is not yet supported for `TypstCommand`
                 redirect_stdio(stdout=out, stderr=err) do
-                    run(ignorestatus(addenv(typst`compile temp.typ`, "TYPST_FONT_PATHS" => julia_mono)))
+                    run(ignorestatus(addenv(typst`compile temp.typ`, "TYPST_FONT_PATHS" => Typstry.julia_mono)))
                 end
 
                 close(out.in)


### PR DESCRIPTION
See the [Typstry.jl news](https://github.com/jakobjpeters/Typstry.jl/blob/v0.3.0/NEWS.md) for a detailed list of updates.

- Fixes the Typst example (that I made in #48) incorrectly using `∂x` instead of correctly using `dx`
- Enables users to use `typst"#set text(font: \"JuliaMono\")"`
    - This typeface could be made the default in the `preamble`, but I'll leave that up to you :)