### PR TITLE
Fixing the use of Ghostscript `gs` command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /docs/site/
 /docs/Manifest.toml
 test/test_images
+examples/out

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,13 @@
+# Examples
+
+To run those examples, clone the project, resolve Julia dependencies and run from the root of this directory:
+
+Example 1:
+```
+julia examples/readme_example_2.jl
+```
+
+Example 2:
+```
+julia examples/readme_example_2.jl
+```

--- a/examples/readme_example_1.jl
+++ b/examples/readme_example_1.jl
@@ -1,0 +1,39 @@
+using Makie
+include("../src/MakieTeX.jl")
+using .MakieTeX
+using CairoMakie # or whichever other backend
+
+# Get Ghostscript path from the environment variable
+ghostscript_path = get(ENV, "GHOSTSCRIPT_PATH", "/usr/bin/gs")  # Fallback to a default path if not set
+
+# Set MakieTeX to use the custom Ghostscript path
+MakieTeX.Ghostscript_jll.gs() = ghostscript_path
+
+# Print to confirm the overridden path
+println("Using Ghostscript at: ", MakieTeX.Ghostscript_jll.gs())
+
+fig = Figure()
+l1 = LTeX(
+    fig[1, 1], L"A \emph{convex} function $f \in C$ is \textcolor{blue}{denoted} as \tikz{\draw[line width=1pt, >->] (0, -2pt) arc (-180:0:8pt);}";
+    tellwidth = false, tellheight = true
+)
+ax1 = Axis(
+    fig[2, 1];
+)
+heatmap!(ax1, Makie.peaks())
+
+display(fig)
+
+# Save the figure to a file in the current directory
+output_dir = "examples/out"
+output_filename = "output_image_1.png"
+img_output_path = joinpath(output_dir, output_filename)
+
+# Check if the directory exists, else create it
+if !isdir(output_dir)
+    println("Directory $output_dir does not exist. Creating it...")
+    mkdir(output_dir)
+end
+
+println("Saving the figure to $img_output_path")
+save(img_output_path, fig)

--- a/examples/readme_example_2.jl
+++ b/examples/readme_example_2.jl
@@ -1,0 +1,37 @@
+using Makie
+include("../src/MakieTeX.jl")
+using .MakieTeX
+using CairoMakie # or whichever other backend
+
+println("testing MakieTeX")
+
+# log which tex engine is being used
+println("Using TeX engine: $(MakieTeX.CURRENT_TEX_ENGINE[])")
+
+fig = Figure(size = (400, 300), pt_per_unit = 2);
+tex1 = LTeX(
+    fig[1, 1], 
+    L"\int \mathbf E \cdot d\mathbf a = \frac{Q_{encl}}{4\pi\epsilon_0}", 
+    scale=1,
+    render_density = 2,
+);
+tex2 = LTeX(
+    fig[2, 1], 
+    L"\int \mathbf E \cdot d\mathbf a = \frac{Q_{encl}}{4\pi\epsilon_0}", 
+    scale=2,
+    render_density = 2,
+);
+
+# Save the figure to a file in the current directory
+output_dir = "examples/out"
+output_filename = "output_image_2.png"
+img_output_path = joinpath(output_dir, output_filename)
+
+# Check if the directory exists, else create it
+if !isdir(output_dir)
+    println("Directory $output_dir does not exist. Creating it...")
+    mkdir(output_dir)
+end
+
+println("Saving the figure to $img_output_path")
+save(img_output_path, fig)

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1737525964,
+        "narHash": "sha256-3wFonKmNRWKq1himW9N3TllbeGIHFACI5vmLpk6moF8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "5757bbb8bd7c0630a0cc4bb19c47e588db30b97c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,41 @@
+{
+  description = "Julia environment";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = github:numtide/flake-utils;
+  };
+
+  outputs = { self, nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        # Override the Nix package set to allow unfree packages
+        pkgs = import nixpkgs {
+          system = system; 
+          config.allowUnfree = true; 
+        };
+        # WARN: Nix packaging system doesn't support all packages, so rely on Julia package manager instead.
+        # Use Julia in REPL mode, then package mode and install packages that way.
+        julia = pkgs.julia-bin.overrideDerivation (oldAttrs: { doInstallCheck = false; });
+      in
+      {
+        # development environment
+        devShells.default = pkgs.mkShell {
+          packages = [
+            julia
+            pkgs.ghostscript
+            # LaTeX
+            pkgs.texlive.combined.scheme-full
+          ];
+
+          shellHook = ''
+            export JULIA_NUM_THREADS="auto"
+            export JULIA_PROJECT="."
+            export JULIA_BINDIR=${julia}/bin
+            export JULIA_EDITOR="code"
+            echo "Nix shell loaded."
+          '';
+        };
+      }
+    );
+}

--- a/src/MakieTeX.jl
+++ b/src/MakieTeX.jl
@@ -17,7 +17,7 @@ using DocStringExtensions
 using Poppler_jll, Ghostscript_jll, Glib_jll, tectonic_jll
 using Rsvg, Cairo
 
-# Define some constants for configuration
+# Define some constant references for configuration
 "Render with Poppler pipeline (true) or Cairo pipeline (false)"
 const RENDER_EXTRASAFE = Ref(false)
 "The current `TeX` engine which MakieTeX uses."
@@ -26,6 +26,15 @@ const CURRENT_TEX_ENGINE = Ref{Cmd}(`lualatex`)
 const _PDFCROP_DEFAULT_MARGINS = Ref{Vector{UInt8}}([0,0,0,0])
 "Default density when rendering images"
 const RENDER_DENSITY = Ref(3)
+
+# Runtime checks
+"Boolean that determines whether the command `gs` (Ghostscript) is available in the shell or not."
+const GHOSTSCRIPT_AVAILABLE = if isnothing(Sys.which("gs"))
+    @warn "Failed to find 'gs' in shell path. Defaulting to use Ghostscript_jll. If this fails, please include Ghostscript command `gs` in current shell." 
+    false 
+else 
+    true 
+end
 
 @deprecate TEXT_RENDER_DENSITY RENDER_DENSITY
 

--- a/src/rendering/pdf_utils.jl
+++ b/src/rendering/pdf_utils.jl
@@ -5,22 +5,13 @@ This file contains a common core for working with PDFs.  It does not contain any
 but functions from here are used in the PDF and TeX rendering pipelines.
 =#
 
-# Check for the existence of the `gs` command in the shell
-has_shell_gs = try
-    run(pipeline(`which gs`, stdout=devnull, stderr=devnull))
-    true
-catch e
-    @warn "Failed to find 'gs' in shell path. Defaulting to use Ghostscript_jll. If this fails, please include Ghostscript command `gs` in current shell." exception=(e, catch_backtrace())
-    false
-end
-
 """
     ghostscript_gs(command_string::String)
 
 Run a Ghostscript command string.  If the `gs` command is available in the shell, it will be used.  Otherwise, the Ghostscript executable from the `Ghostscript_jll` package will be used.
 """
 function ghostscript_gs(command_string::Cmd)
-    if has_shell_gs
+    if GHOSTSCRIPT_AVAILABLE
         return `gs $command_string`
     else
         return `$(Ghostscript_jll.gs()) $command_string`


### PR DESCRIPTION
This PR is linked to the following issue: [Issue 67](https://github.com/MakieOrg/MakieTeX.jl/issues/67)

I just moved all code that was building a `gs` command into a dedicated function that checks if the `gs` command is available in the shell, else defaults to use `Ghostscript_jll`.

This allows to fix the issue on Nixos.